### PR TITLE
movement arrow refactorings

### DIFF
--- a/Assets/MovementArrow.cs
+++ b/Assets/MovementArrow.cs
@@ -5,261 +5,146 @@ using UnityEngine;
 
 public class MovementArrow : MonoBehaviour
 {
-    // public static void DrawArrowPath(List<Vector3> path)
-    // {
-    //     Sprite[] sprites = Resources.LoadAll<Sprite>("Sprites/UI");
-    //     Sprite sprite = null;
 
-    //     for (int i = 0; i < path.Count; i++)
-    //     {
-    //         if (path.Count == 1)
-    //         {
-    //             continue;
-    //         }
-
-    //         // Draw tail
-    //         if (i == 0)
-    //         {
-    //             // Arrow moving up
-    //             if (path[i + 1].y > path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_tail_down").First();
-    //             }
-
-    //             // Arrow moving down
-    //             else if (path[i + 1].y < path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_tail_up").First();
-    //             }
-
-    //             // Arrow moving right
-    //             else if (path[i + 1].x > path[i].x)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_tail_left").First();
-    //             }
-
-    //             // Arrow moving left
-    //             else if (path[i + 1].x < path[i].x)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_tail_right").First();
-    //             }
-    //         }
-
-    //         // Draw head
-    //         else if (i == path.Count - 1)
-    //         {
-    //             // Arrow moving up
-    //             if (path[i - 1].y > path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_down").First();
-    //             }
-
-    //             // Arrow moving down
-    //             else if (path[i - 1].y < path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_up").First();
-    //             }
-
-    //             // Arrow moving right
-    //             else if (path[i - 1].x > path[i].x)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_left").First();
-    //             }
-
-    //             // Arrow moving left
-    //             else
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_right").First();
-    //             }
-    //         }
-
-    //         // Draw straight line
-    //         else if (path.Count > 2 && (path[i].y == path[i - 1].y && path[i].y == path[i + 1].y || path[i].x == path[i - 1].x && path[i].x == path[i + 1].x))
-    //         {
-    //             if (path[i].y == path[i - 1].y && path[i].y == path[i + 1].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_straight_horizontal").First();
-    //             }
-    //             else
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_straight_vertical").First();
-    //             }
-    //         }
-
-    //         // Draw curve
-    //         else if (path.Count >= 3)
-    //         {
-    //             // Bottom right curve
-    //             if (path[i - 1].x < path[i].x && path[i + 1].y > path[i].y || path[i - 1].y > path[i].y && path[i + 1].x < path[i].x)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_curve_bottomright").First();
-    //             }
-
-    //             // Bottom left curve
-    //             else if (path[i - 1].x > path[i].x && path[i + 1].y > path[i].y || path[i - 1].y > path[i].y && path[i + 1].x > path[i].x)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_curve_bottomleft").First();
-    //             }
-
-    //             // Top left curve
-    //             else if (path[i - 1].x > path[i].x && path[i + 1].y < path[i].y || path[i + 1].x > path[i].x && path[i - 1].y < path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_curve_topleft").First();
-    //             }
-
-    //             // Top right curve
-    //             else if (path[i - 1].x < path[i].x && path[i + 1].y < path[i].y || path[i + 1].x < path[i].x && path[i - 1].y < path[i].y)
-    //             {
-    //                 sprite = sprites.Where(s => s.name == "arrow_curve_topright").First();
-    //             }
-    //         }
-
-    //         DrawArrow(path[i], sprite);
-    //     }
-    // }
+    public Sprite arrowTailDown;
+    public Sprite arrowTailUp;
+    public Sprite arrowTailLeft;
+    public Sprite arrowTailRight;
+    public Sprite arrowDown;
+    public Sprite arrowUp;
+    public Sprite arrowLeft;
+    public Sprite arrowRight;
+    public Sprite arrowStraightHorizontal;
+    public Sprite arrowStraightVertical;
+    public Sprite arrowCurveBottomLeft;
+    public Sprite arrowCurveBottomRight;
+    public Sprite arrowCurveTopLeft;
+    public Sprite arrowCurveTopRight;
 
 
-    // private static void DrawArrow(Vector3 position, Sprite sprite)
-    // {
-    //     GameObject spriteObject = new GameObject() { tag = "MovementArrow" };
-    //     spriteObject.AddComponent<SpriteRenderer>();
-
-    //     spriteObject.transform.position = position;
-    //     spriteObject.GetComponent<SpriteRenderer>().sprite = sprite;
-    // }
-
-
-
-    public static void DrawArrowPath(List<Vector3> path)
+    public void DrawArrowPath(List<Vector3> path)
     {
-        if (path.Count == 1)
-        {
-            return;
-        }
-
-        Sprite[] sprites = Resources.LoadAll<Sprite>("Sprites/UI");
 
         for (int i = 0; i < path.Count; i++)
         {
-            Vector3 prev = i > 1 ? path[i - 1] : Vector3.zero;
+            if (path.Count == 1)
+            {
+                return;
+            }
+
             Vector3 cur = path[i];
-            Vector3 next = path[i + 1];
+            Vector3 next = i < path.Count-1 ? path[i+1] : Vector3.zero;
+            Vector3 prev = i > 0 ? path[i-1] : Vector3.zero;
 
-            bool tail_down = next.y > cur.y;
-            bool tail_up = next.y < cur.y;
-            bool tail_left = next.x < cur.x;
-            bool tail_right = next.x > cur.x;
-
-            bool head_down = prev.y > cur.y;
-            bool head_up = prev.y < cur.y;
-            bool head_right = prev.x > cur.x;
-            bool head_left = prev.x < cur.x;
+            bool tailDown = next.y > cur.y;
+            bool tailUp = next.y < cur.y;
+            bool tailLeft = next.x > cur.x;
+            bool tailRight = next.x < cur.x;
+            bool headDown = prev.y > cur.y;
+            bool headUp = prev.y < cur.y;
+            bool headLeft = prev.x > cur.x;
+            bool headRight = prev.x < cur.x;
 
             // Draw tail
             if (i == 0)
             {
-
-
-                if (tail_down)
-                {
-                    DrawSegment(sprites, cur, "arrow_tail_down");
-                }
-                else if (tail_up)
-                {
-                    DrawSegment(sprites, cur, "arrow_tail_up");
-                }
-                else if (tail_left)
-                {
-                    DrawSegment(sprites, cur, "arrow_tail_left");
-                }
-                else
-                {
-                    DrawSegment(sprites, cur, "arrow_tail_right");
-                }
-            }
-
-            // Draw head
-            else if (i == path.Count - 1)
-            {
-
-
                 // Arrow moving up
-                if (head_down)
+                if (tailDown)
                 {
-                    DrawSegment(sprites, cur, "arrow_down");
+                    DrawSegment(cur, arrowTailDown);
                 }
 
                 // Arrow moving down
-                else if (head_up)
+                else if (tailUp)
                 {
-                    DrawSegment(sprites, cur, "arrow_up");
+                    DrawSegment(cur, arrowTailUp);
                 }
 
                 // Arrow moving right
-                else if (head_right)
+                else if (tailLeft)
                 {
-                    DrawSegment(sprites, cur, "arrow_left");
+                    DrawSegment(cur, arrowTailLeft);
+                }
+
+                // Arrow moving left
+                else if (tailRight)
+                {
+                    DrawSegment(cur, arrowTailRight);
+                }
+            }
+            // Draw head
+            else if (i == path.Count - 1)
+            {
+                // Arrow moving up
+                if (headDown)
+                {
+                    DrawSegment(cur, arrowDown);
+                }
+
+                // Arrow moving down
+                else if (headUp)
+                {
+                    DrawSegment(cur, arrowUp);
+                }
+
+                // Arrow moving right
+                else if (headLeft)
+                {
+                    DrawSegment(cur, arrowLeft);
                 }
 
                 // Arrow moving left
                 else
                 {
-                    DrawSegment(sprites, cur, "arrow_right");
+                    DrawSegment(cur, arrowRight);
                 }
             }
-
             // Draw straight line
-            else if (path.Count > 2 && (cur.y == prev.y && cur.y == next.y || cur.x == prev.x && cur.x == next.x))
+            else if (path.Count > 2 && ((cur.y == prev.y && cur.y == next.y) || (cur.x == prev.x && cur.x == next.x)))
             {
                 if (cur.y == prev.y)
                 {
-                    DrawSegment(sprites, cur, "arrow_straight_horizontal");
+                    DrawSegment(cur, arrowStraightHorizontal);
                 }
                 else
                 {
-                    DrawSegment(sprites, cur, "arrow_straight_vertical");
+                    DrawSegment(cur, arrowStraightVertical);
                 }
             }
             // Draw curve
-            else if (path.Count >= 3)
+            else if ((headRight && tailDown) || (headDown && tailRight))
             {
-                // Bottom right curve
-                if (head_left && tail_down || head_down && tail_left)
-                {
-                    DrawSegment(sprites, cur, "arrow_curve_bottomright");
-                }
-
-                // Bottom left curve
-                else if (head_right && tail_down || head_down && tail_right)
-                {
-                    DrawSegment(sprites, cur, "arrow_curve_bottomleft");
-                }
-
-                // Top left curve
-                else if (head_right && tail_up || tail_right && head_up)
-                {
-                    DrawSegment(sprites, cur, "arrow_curve_topleft");
-                }
-
-                // Top right curve
-                else if (head_left && tail_up || tail_left && head_up)
-                {
-                    DrawSegment(sprites, cur, "arrow_curve_topright");
-                }
+                DrawSegment(cur, arrowCurveBottomRight);
+            }
+            // Bottom left curve
+            else if ((headLeft && tailDown) || (headDown && tailLeft))
+            {
+                DrawSegment(cur, arrowCurveBottomLeft);
+            }
+            // Top left curve
+            else if ((headLeft && tailUp) || (tailLeft && headUp))
+            {
+                DrawSegment(cur, arrowCurveTopLeft);
+            }
+            // Top right curve
+            else if ((headRight && tailUp) || (tailRight && headUp))
+            {
+                DrawSegment(cur, arrowCurveTopRight);
             }
         }
     }
 
-    private static void DrawSegment(Sprite[] sprites, Vector3 position, string sprite_name)
+
+    private static void DrawSegment(Vector3 position, Sprite sprite)
     {
         GameObject spriteObject = new GameObject() { tag = "MovementArrow" };
         spriteObject.AddComponent<SpriteRenderer>();
 
         spriteObject.transform.position = position;
-        spriteObject.GetComponent<SpriteRenderer>().sprite = sprites.Where(s => s.name == sprite_name).First();
+        spriteObject.GetComponent<SpriteRenderer>().sprite = sprite;
     }
 
-    public static void EraseArrows()
+    public void EraseArrows()
     {
         GameObject[] arrows = GameObject.FindGameObjectsWithTag("MovementArrow");
         foreach (GameObject arrow in arrows)

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2718,6 +2718,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 51cbc57f56188fc448eaa219693a7f9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1261429858 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6270806920202185563, guid: 9d34e50fe559aba45b7cee36efefba08, type: 3}
+  m_PrefabInstance: {fileID: 1839608957}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1452245133 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 381468899672501547, guid: 9d34e50fe559aba45b7cee36efefba08, type: 3}
@@ -3321,12 +3326,38 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2411854483388046239, guid: 9d34e50fe559aba45b7cee36efefba08, type: 3}
   m_PrefabInstance: {fileID: 1839608957}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 1261429858}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 51cbc57f56188fc448eaa219693a7f9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2014902512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1261429858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b8602b91010f9064d95cb7d4e2c6d9a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  arrowTailDown: {fileID: -342039230, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowTailUp: {fileID: 1757992785, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowTailLeft: {fileID: -149571576, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowTailRight: {fileID: -2130905135, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowDown: {fileID: 741743897, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowUp: {fileID: -1591014949, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowLeft: {fileID: 576038685, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowRight: {fileID: 2059442317, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowStraightHorizontal: {fileID: 898828940, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowStraightVertical: {fileID: 23370952, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowCurveBottomLeft: {fileID: -361690648, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowCurveBottomRight: {fileID: 1264424565, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowCurveTopLeft: {fileID: 739517906, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
+  arrowCurveTopRight: {fileID: 1710696540, guid: 73614dce9023e54408b5161b1bf0952d, type: 3}
 --- !u!1 &2016273772
 GameObject:
   m_ObjectHideFlags: 0
@@ -3372,6 +3403,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1d530625d3e012f438914531d8fb2f9d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  movementArrow: {fileID: 2014902512}
 --- !u!114 &2016273776
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Utility/Test.cs
+++ b/Assets/Scripts/Utility/Test.cs
@@ -8,6 +8,7 @@ using UnityEditor;
 public class Test : MonoBehaviour
 {
     public PlayerControls controls;
+    public MovementArrow movementArrow;
     private Pathfinding pathfinding;
     private GameObject marcel;
     private PathNode activeArrowNode;
@@ -52,8 +53,8 @@ public class Test : MonoBehaviour
         List<Vector3> vectorPath = pathfinding.FindPath(marcel.transform.position, position);
         if (vectorPath != null)
         {
-            MovementArrow.EraseArrows();
-            MovementArrow.DrawArrowPath(vectorPath);
+            movementArrow.EraseArrows();
+            movementArrow.DrawArrowPath(vectorPath);
         }
     }
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.18",
+    "com.unity.collab-proxy": "1.17.1",
     "com.unity.feature.2d": "1.0.0",
-    "com.unity.ide.rider": "3.0.14",
-    "com.unity.ide.visualstudio": "2.0.15",
+    "com.unity.ide.rider": "3.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.3.0",
     "com.unity.test-framework": "1.1.31",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -56,7 +56,7 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "7.0.4",
+      "version": "7.0.5",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -85,7 +85,7 @@
       }
     },
     "com.unity.burst": {
-      "version": "1.6.5",
+      "version": "1.6.6",
       "depth": 3,
       "source": "registry",
       "dependencies": {
@@ -94,7 +94,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "1.15.18",
+      "version": "1.17.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -118,13 +118,13 @@
         "com.unity.2d.pixel-perfect": "5.0.1",
         "com.unity.2d.psdimporter": "6.0.4",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.spriteshape": "7.0.4",
+        "com.unity.2d.spriteshape": "7.0.5",
         "com.unity.2d.tilemap": "1.0.0",
         "com.unity.2d.tilemap.extras": "2.2.3"
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.14",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -133,7 +133,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.15",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -172,7 +172,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.4.0",
+      "version": "1.4.2",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.5f1
-m_EditorVersionWithRevision: 2021.3.5f1 (40eb3a945986)
+m_EditorVersion: 2021.3.7f1
+m_EditorVersionWithRevision: 2021.3.7f1 (24e8595d6d43)


### PR DESCRIPTION
aside from pulling stuff into variables, this defines sprites as class members which can be defined in the unity ui. it's a little clunky, and one could probably do it more programmatically in a `Start()` function (e.g. `Resources.LoadAll()` and set all the sprites with the linq approach), but idk if it's much better. 

since we're now using class members in our main function, it can't be static anymore. also, i've registered it as a component in Marcel (as it felt like it made most sense there), but i have to point to that instance in Testing at the moment. i'm sure you'll see how it flows. :)

also, sorry about bumping a bunch of versions. idk how that happened