### PR TITLE
iffy recursive approach to finding movement area

### DIFF
--- a/Assets/Scripts/Pathfinding/Pathfinding.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinding.cs
@@ -78,20 +78,19 @@ public class Pathfinding
 
     public void FindMovementArea(int radius, PathNode startNode, int currentDepth)
     {
-        if (currentDepth < radius)
+        if (!movePositions.Contains(startNode.worldPosition) && currentDepth <= radius)
         {
+            movePositions.Add(startNode.worldPosition);
             foreach (PathNode neighbour in startNode.neighbours) 
             {
                 FindMovementArea(radius, neighbour, currentDepth + 1);
             }
         }
-        if (!movePositions.Contains(startNode.worldPosition)) {
-            movePositions.Add(startNode.worldPosition);
-        }
     }
 
     public List<Vector3> FindMovementArea(int radius, PathNode startNode)
     {
+        movePositions.Clear();
         FindMovementArea(radius, startNode, 0);
         return movePositions;
     }

--- a/Assets/Scripts/Utility/Testing.cs
+++ b/Assets/Scripts/Utility/Testing.cs
@@ -55,7 +55,9 @@ public class Testing : MonoBehaviour
     {
         Stopwatch stopwatch = new Stopwatch();
         stopwatch.Start();
-        List<Vector3> moveableTiles = pathfinding.FindMovementArea(movement, marcel.transform.position);
+        pathfinding.GetGrid().GetXYFromPosition(marcel.transform.position, out int marcelX, out int marcelY);
+        List<Vector3> moveableTiles = pathfinding.FindMovementArea(movement, pathfinding.GetNode(marcelX-1, marcelY-1));
+        //List<Vector3> moveableTiles = pathfinding.FindMovementArea(movement, marcel.transform.position);
         foreach (Vector3 tile in moveableTiles)
         {
             DrawMovementTile(tile + new Vector3(1, 1));


### PR DESCRIPTION
this commit adds only *walkable* neighbours to each node on init. this makes closedList irrelevant in `FindPath`.

i've also made a recursive method which steps through each neighbour's neighbours and so on and adds those to `movePositions`, until the desired depth is reached. it's a little faster than the iterative version until the radius is about ~10. it depends on your idea of game design whether that's good enough or whether we should look for further optimizations in either approach.